### PR TITLE
feat: add blog pages with comments and likes

### DIFF
--- a/src/app/blog/BlogInteractions.tsx
+++ b/src/app/blog/BlogInteractions.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { useState, FormEvent } from 'react';
+
+interface Comment {
+  name: string;
+  text: string;
+}
+
+export default function BlogInteractions() {
+  const [likes, setLikes] = useState(0);
+  const [name, setName] = useState('');
+  const [comment, setComment] = useState('');
+  const [comments, setComments] = useState<Comment[]>([]);
+
+  const handleLike = () => setLikes(likes + 1);
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !comment.trim()) return;
+    setComments([...comments, { name, text: comment }]);
+    setName('');
+    setComment('');
+  };
+
+  return (
+    <div className="mt-8 space-y-6">
+      <button
+        onClick={handleLike}
+        className="px-4 py-2 rounded-md bg-primary text-primary-foreground"
+      >
+        Like ({likes})
+      </button>
+
+      <form onSubmit={handleSubmit} className="space-y-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Your name"
+          className="w-full rounded-md border border-border p-2"
+        />
+        <textarea
+          value={comment}
+          onChange={(e) => setComment(e.target.value)}
+          placeholder="Your comment"
+          className="w-full rounded-md border border-border p-2"
+        />
+        <button
+          type="submit"
+          className="px-4 py-2 rounded-md bg-primary text-primary-foreground"
+        >
+          Add Comment
+        </button>
+      </form>
+
+      {comments.length > 0 && (
+        <ul className="space-y-2">
+          {comments.map((c, idx) => (
+            <li key={idx} className="border-b border-border pb-2">
+              <span className="font-semibold">{c.name}:</span> {c.text}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { blogs } from '@/data/blogs';
+import BlogInteractions from '../BlogInteractions';
+
+interface BlogPostPageProps {
+  params: { slug: string };
+}
+
+export default function BlogPostPage({ params }: BlogPostPageProps) {
+  const post = blogs.find(b => b.slug === params.slug);
+
+  if (!post) {
+    return <div className="p-8">Post not found.</div>;
+  }
+
+  const otherPosts = blogs.filter(b => b.slug !== post.slug);
+
+  return (
+    <div className="max-w-3xl mx-auto p-8 space-y-8">
+      <div>
+        <h1 className="text-3xl font-bold mb-4">{post.title}</h1>
+        <p className="whitespace-pre-line text-foreground">{post.content}</p>
+      </div>
+
+      <BlogInteractions />
+
+      {otherPosts.length > 0 && (
+        <div className="mt-12">
+          <h2 className="text-2xl font-semibold mb-4">Read more</h2>
+          <ul className="space-y-2">
+            {otherPosts.map(p => (
+              <li key={p.slug}>
+                <Link className="text-primary underline" href={`/blog/${p.slug}`}>
+                  {p.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -1,0 +1,17 @@
+import Link from 'next/link';
+import { blogs } from '@/data/blogs';
+
+export default function BlogPage() {
+  return (
+    <div className="max-w-3xl mx-auto p-8 space-y-8">
+      <h1 className="text-3xl font-bold">Blog</h1>
+      {blogs.map(post => (
+        <div key={post.slug} className="space-y-2">
+          <h2 className="text-2xl font-semibold">{post.title}</h2>
+          <p className="text-muted-foreground">{post.excerpt}</p>
+          <Link className="text-primary underline" href={`/blog/${post.slug}`}>Read more</Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/data/blogs.ts
+++ b/src/data/blogs.ts
@@ -1,0 +1,27 @@
+export type BlogPost = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  content: string;
+};
+
+export const blogs: BlogPost[] = [
+  {
+    slug: 'my-first-post',
+    title: 'My First Blog Post',
+    excerpt: 'This is a short introduction to my first post where I talk about building a portfolio with Next.js.',
+    content: `Welcome to my blog! This is my first post on the site.
+
+In this article, I share how I built this portfolio using Next.js and Tailwind CSS.
+
+Thanks for reading!`
+  },
+  {
+    slug: 'another-day-another-post',
+    title: 'Another Day, Another Post',
+    excerpt: 'Some thoughts on writing content and sharing updates with the world.',
+    content: `Writing consistently is hard, but it is also rewarding.
+
+With every post I try to improve a little bit and share something new.`
+  }
+];


### PR DESCRIPTION
## Summary
- add static blog data
- list blogs with link to full pages
- allow liking and commenting on blog posts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689d1740b4cc8333a4558ffc4fbad6da